### PR TITLE
Release/124

### DIFF
--- a/CWebRTC.podspec
+++ b/CWebRTC.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = 'CWebRTC'
-  spec.version      = '120'
+  spec.version      = '124'
   spec.summary      = 'Community distribution of WebRTC framework binaries for iOS.'
   spec.description  = <<-DESC
   This pod contains community distribution of WebRTC framework binaries for iOS.
@@ -12,6 +12,6 @@ Pod::Spec.new do |spec|
   spec.author       = { 'Ayham Hylam' => 'Ayham Hylam' }
   spec.ios.deployment_target = '12.0'
 
-  spec.source = { http: 'https://github.com/ayham-achami/CWebRTC/releases/download/120/WebRTC-M120.xcframework.zip' }
+  spec.source = { http: 'https://github.com/ayham-achami/CWebRTC/releases/download/124/WebRTC-M124.xcframework.zip' }
   spec.vendored_frameworks = 'WebRTC.xcframework'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "WebRTC",
-                      url: "https://github.com/ayham-achami/CWebRTC/releases/download/120/WebRTC-M120.xcframework.zip",
-                      checksum: "36cef0ac01b6d5b93fd054d02de4005877bc5442a8d5aebd7efd87fe694e3e7c")
+                      url: "https://github.com/ayham-achami/CWebRTC/releases/download/124/WebRTC-M124.xcframework.zip",
+                      checksum: "30f1f79362dc59529ea3dbe66b2a22120ef73f0789bfd7149242b2ced9f6098b")
     ]
 )


### PR DESCRIPTION
webrtc M124 (6367)
+
Audio screensharing support via custom APM per-sender +
Revert af74dff19ee8fffd4b4dd1c807518eebb401db39
"Allow streams to be sent without |source_| being initially set" because of high CPU